### PR TITLE
Return correct result for getBoolean

### DIFF
--- a/src/ios/FirebaseConfigPlugin.m
+++ b/src/ios/FirebaseConfigPlugin.m
@@ -60,7 +60,7 @@
 - (void)getBoolean:(CDVInvokedUrlCommand *)command {
     FIRRemoteConfigValue *configValue = [self getConfigValue:command];
     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                                                        messageAsBool:configValue.boolValue];
+                                                        messageAsInt:configValue.boolValue ? 1 : 0];
 
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }


### PR DESCRIPTION
The javascript does a comparison of `value === 1` in `getBoolean`. The android plugin correctly returns 1 or 0 but the ios version was returning true or false. This is the simplest fix for this error although I'm curious why we don't just return boolean values?